### PR TITLE
direct memory to memory processing instead of streams

### DIFF
--- a/brotlidecpy/bit_reader.py
+++ b/brotlidecpy/bit_reader.py
@@ -2,95 +2,57 @@
 # Distributed under MIT license.
 # See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
 
-BROTLI_READ_SIZE = 4096
-BROTLI_IBUF_SIZE = (2 * BROTLI_READ_SIZE + 32)
-BROTLI_IBUF_MASK = (2 * BROTLI_READ_SIZE - 1)
 kBitMask = [
-    0, 1, 3, 7, 15, 31, 63, 127, 255, 511, 1023, 2047, 4095, 8191, 16383, 32767,
-    65535, 131071, 262143, 524287, 1048575, 2097151, 4194303, 8388607, 16777215
+    0x000000, 0x000001, 0x000003, 0x000007, 0x00000f, 0x00001f, 0x00003f, 0x00007f,
+    0x0000ff, 0x0001ff, 0x0003ff, 0x0007ff, 0x000fff, 0x001fff, 0x003fff, 0x007fff,
+    0x00ffff, 0x01ffff, 0x03ffff, 0x07ffff, 0x0fffff, 0x1fffff, 0x3fffff, 0x7fffff,
+    0xffffff
 ]
 
 
 class BrotliBitReader:
-    def __init__(self, input_stream):
-        self.buf_ = bytearray([0] * BROTLI_IBUF_SIZE)
-        self.input_ = input_stream    # input stream
-        self.buf_ptr_ = 0      # next input will write here
-        self.val_ = 0          # pre-fetched bits
+    """Wrap a bytes buffer to enable reading 0 < n <=24 bits at a time, or transfer of arbitrary number of bytes"""
+    def __init__(self, input_buffer):
+        self.buf_ = input_buffer
+        self.buf_len_ = len(input_buffer)
         self.pos_ = 0          # byte position in stream
-        self.bit_pos_ = 0      # current bit-reading position in val_
-        self.bit_end_pos_ = 0  # bit-reading end position from LSB of val_
-        self.eos_ = 0          # input stream is finished
-        self.reset()
-
-    READ_SIZE = BROTLI_READ_SIZE
-    IBUF_MASK = BROTLI_IBUF_MASK
+        self.bit_pos_ = 0      # current bit-reading position in current byte (number bits already read from byte, 0-7)
 
     def reset(self):
-        self.buf_ptr_ = 0      # next input will write here
-        self.val_ = 0          # pre-fetched bits
-        self.pos_ = 0          # byte position in stream
-        self.bit_pos_ = 0      # current bit-reading position in val_
-        self.bit_end_pos_ = 0  # bit-reading end position from LSB of val_
-        self.eos_ = 0          # input stream is finished
+        """Reset an initialized BrotliBitReader to start of input buffer"""
+        self.pos_ = 0
+        self.bit_pos_ = 0
 
-        self.read_more_input()
-        for i in range(0, 4):
-            self.val_ |= self.buf_[self.pos_] << (8 * i)
-            self.pos_ += 1
-        return self.bit_end_pos_ > 0
+    def peek_bits(self, n_bits):
+        """Get value a n_bits unsigned integer treating input as little-endian byte stream, without advancing pointer"""
+        val = 0
+        bytes_shift = 0
+        buf_pos = self.pos_
+        bit_pos_when_done = n_bits + self.bit_pos_
+        while bytes_shift < bit_pos_when_done:
+            if buf_pos >= self.buf_len_:
+                break  # if hit end of buffer, this simulates zero padding after end, which is correct
+            val |= self.buf_[buf_pos] << bytes_shift
+            bytes_shift += 8
+            buf_pos += 1
+        return (val >> self.bit_pos_) & kBitMask[n_bits]
 
-    def read_more_input(self):
-        """ Fills up the input ringbuffer by calling the input callback.
-
-       Does nothing if there are at least 32 bytes present after current position.
-
-       Returns 0 if either:
-        - the input callback returned an error, or
-        - there is no more input and the position is past the end of the stream.
-
-       After encountering the end of the input stream, 32 additional zero bytes are
-       copied to the ringbuffer, therefore it is safe to call this function after
-       every 32 bytes of input is read"""
-        if self.bit_end_pos_ > 256:
-            return
-        elif self.eos_:
-            if self.bit_pos_ > self.bit_end_pos_:
-                raise Exception('Unexpected end of input %s %s' % (self.bit_pos_, self.bit_end_pos_))
-        else:
-            dst = self.buf_ptr_
-            bytes_read = self.input_.readinto(memoryview(self.buf_)[dst:dst+BROTLI_READ_SIZE])
-            if bytes_read < 0:
-                raise Exception('Unexpected end of input')
-
-            if bytes_read < BROTLI_READ_SIZE:
-                self.eos_ = 1
-                # Store 32 bytes of zero after the stream end
-                for p in range(0, 32):
-                    self.buf_[dst + bytes_read + p] = 0
-
-            if dst == 0:
-                # Copy the head of the ringbuffer to the slack region
-                for p in range(0, 32):
-                    self.buf_[(BROTLI_READ_SIZE << 1) + p] = self.buf_[p]
-                self.buf_ptr_ = BROTLI_READ_SIZE
-            else:
-                self.buf_ptr_ = 0
-
-            self.bit_end_pos_ += bytes_read << 3
-
-    def fill_bit_window(self):
-        """Guarantees that there are at least 24 bits in the buffer"""
-        while self.bit_pos_ >= 8:
-            self.val_ >>= 8
-            self.val_ |= self.buf_[self.pos_ & BROTLI_IBUF_MASK] << 24
-            self.pos_ += 1
-            self.bit_pos_ -= 8
-            self.bit_end_pos_ -= 8
+    def skip_bits(self, n_bits):
+        next_in_bits = self.bit_pos_ + n_bits
+        self.bit_pos_ = next_in_bits & 7
+        self.pos_ += next_in_bits >> 3
 
     def read_bits(self, n_bits):
-        if 32 - self.bit_pos_ < n_bits:
-            self.fill_bit_window()
-        val = ((self.val_ >> self.bit_pos_) & kBitMask[n_bits])
-        self.bit_pos_ += n_bits
+        val = self.peek_bits(n_bits)
+        self.skip_bits(n_bits)
         return val
+
+    def copy_bytes(self, dest_buffer, dest_pos, n_bytes):
+        """Copy bytes from input buffer. This will first skip to next byte boundary if not already on one"""
+        if self.bit_pos_ != 0:
+            self.bit_pos_ = 0
+            self.pos_ += 1
+        if n_bytes > 0:  # call with n_bytes == 0 to just skip to next byte boundary
+            new_pos = self.pos_ + n_bytes
+            memoryview(dest_buffer)[dest_pos:dest_pos+n_bytes] = self.buf_[self.pos_:new_pos]
+            self.pos_ = new_pos

--- a/brotlidecpy/bit_reader.py
+++ b/brotlidecpy/bit_reader.py
@@ -13,7 +13,7 @@ kBitMask = [
 class BrotliBitReader:
     """Wrap a bytes buffer to enable reading 0 < n <=24 bits at a time, or transfer of arbitrary number of bytes"""
     def __init__(self, input_buffer):
-        self.buf_ = input_buffer
+        self.buf_ = bytearray(input_buffer)
         self.buf_len_ = len(input_buffer)
         self.pos_ = 0          # byte position in stream
         self.bit_pos_ = 0      # current bit-reading position in current byte (number bits already read from byte, 0-7)


### PR DESCRIPTION
Since the one exported method of this package uses an in-memory buffer for input and returns an in-memory buffer as output, this change removes all the code copied from the C reference version that made use of byte streams and intermediate ringbuffers. It also streamlines the BrotliBitReader class and fixes up all places where other classes made use of the internal implementation details of BrotliBitReader, ensuring that all access to the class is via the few methods that are intended to be part of its API. The tests seem to run slightly faster or with little change in speed.